### PR TITLE
fix - fixes cypher versioning for updating term, nodes and routes methods

### DIFF
--- a/pysts/app/main/routes.py
+++ b/pysts/app/main/routes.py
@@ -107,7 +107,7 @@ def models(name=None):
         )
 
 @bp.route("/nodes", defaults={'nodeid': None}, methods=['GET', 'POST'])
-@bp.route('/nodes/<nodeid>')
+@bp.route('/nodes/<nodeid>', methods=['GET', 'POST'])
 @login_required
 def nodes(nodeid):
 
@@ -181,7 +181,7 @@ def nodes(nodeid):
 
 
 @bp.route("/properties", defaults={'propid': None}, methods=['GET', 'POST'])
-@bp.route('/properties/<propid>')
+@bp.route('/properties/<propid>', methods=['GET', 'POST'])
 @login_required
 def properties(propid):
 
@@ -232,7 +232,7 @@ def properties(propid):
 
 
 @bp.route("/valuesets", defaults={'valuesetid': None}, methods=['GET', 'POST'])
-@bp.route('/valuesets/<valuesetid>')
+@bp.route('/valuesets/<valuesetid>', methods=['GET', 'POST'])
 @login_required
 def valuesets(valuesetid):
 
@@ -283,7 +283,7 @@ def valuesets(valuesetid):
 
 
 @bp.route("/terms", defaults={'termid': None}, methods=['GET', 'POST'])
-@bp.route('/terms/<termid>')
+@bp.route('/terms/<termid>', methods=['GET', 'POST'])
 @login_required
 def terms(termid):
 
@@ -347,7 +347,7 @@ def terms(termid):
 
 
 @bp.route("/origins", defaults={'originid': None}, methods=['GET', 'POST'])
-@bp.route('/origins/<originid>')
+@bp.route('/origins/<originid>', methods=['GET', 'POST'])
 @login_required
 def origins(originid):
     format = request.args.get("format")


### PR DESCRIPTION
1. fixes cypher query for updating cloned term, nodes; update would fail when new clone term had lower id
2. fixes routes.py function signature (update could fail to update for POST /nodes/zwr37o where POST /nodes?id=zwr37o succeeds (see https://stackoverflow.com/questions/20689195/flask-error-method-not-allowed-the-method-is-not-allowed-for-the-requested-url/20689328)