### PR TITLE
feat(admin tools): add cache-clearing tools

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -1398,4 +1398,4 @@ timezone = ["python-dateutil"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "09c0f67d8db7c69289de440555a07061d7ecd742ed9a5fff76e553034dcce2f6"
+content-hash = "53fddaf393543dfb227ddf71a7fbf780a3f41663767cf64b34967aa8f112bc81"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bento-sts"
-version = "0.1.17"
+version = "0.1.18"
 authors = [
 	{ name = "Mark Benson", email = "mark.benson@nih.gov" },
 	{ name = "Mark A. Jensen", email = "mark.jensen@nih.gov" },
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry]
 name = "bento-sts"
-version = "0.1.17"
+version = "0.1.18"
 description = "Bento Simple Terminology Server"
 authors = [
 	"Mark Benson <mark.benson@nih.gov>",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -70,6 +70,7 @@ certifi = "^2025.4.26"
 cryptography = "^45.0.3"
 mako = "^1.3.10"
 babel = "^2.17.0"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
 
 [tool.poetry.group.dev.dependencies]
 pytest-cov = "^6.0.0"

--- a/python/src/bento_sts/config.py
+++ b/python/src/bento_sts/config.py
@@ -1,22 +1,24 @@
 import os
-from bento_sts import config_sts
+
 import yaml
 from importlib_resources import files
 
+from bento_sts import config_sts
+
 src = files(config_sts).joinpath("query_paths.yml")
-with src.open('r') as fh:
+with src.open("r") as fh:
     qp = yaml.load(fh, Loader=yaml.CLoader)
 
 
-class Config(object):
+class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY") or "supposedly-random-passphrase"
     NEO4J_MDB_URI = os.environ.get("NEO4J_MDB_URI")
     NEO4J_MDB_USER = os.environ.get("NEO4J_MDB_USER")
     NEO4J_MDB_PASS = os.environ.get("NEO4J_MDB_PASS")
     FLASK_LOGFILE = os.environ.get("STS_LOGFILE") or "sts.log"
     LANGUAGES = ["en"]
-    MDB = None # set in sts.py
-    MODEL_LIST = [] # set by MDB query in sts.py
+    MDB = None  # set in sts.py
+    MODEL_LIST = []  # set by MDB query in sts.py
     HITS_PER_PAGE = 25
     MAX_ENTS_PER_REQ = 500
     MAX_CONTENT_LENGTH = 2 * 1024 * 1024
@@ -25,4 +27,3 @@ class Config(object):
     EDITING_FORMS = False
     QUERY_PATHS = qp
     WTF_CSRF_CHECK_DEFAULT = False
-

--- a/python/src/bento_sts/main/routes.py
+++ b/python/src/bento_sts/main/routes.py
@@ -888,12 +888,8 @@ def admin_list_indexes():
 
     except Exception as e:
         current_app.logger.exception("Error listing indexes")
-        return jsonify(
-            {
-                "error": str(e),
-                "status": "error",
-            },
-        ), 500
+        flash(f"Error listing indexes: {e!s}", "error")
+        return redirect(url_for("main.admin_dashboard"))
 
 
 @bp.route("/admin/version", methods=["GET"])

--- a/python/src/bento_sts/main/routes.py
+++ b/python/src/bento_sts/main/routes.py
@@ -4,7 +4,6 @@ import re
 from importlib import metadata
 from pathlib import Path
 
-import tomllib
 from flask import (
     Response,
     abort,
@@ -26,6 +25,11 @@ from .forms import (
     SelectModelForm,
     SelectVersionForm,
 )
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 
 def mdb():

--- a/python/src/bento_sts/main/routes.py
+++ b/python/src/bento_sts/main/routes.py
@@ -1,8 +1,15 @@
-import re
+"""Routes for the main STSapplication."""
 
+import re
+from importlib import metadata
+from pathlib import Path
+
+import tomllib
 from flask import (
+    Response,
     abort,
     current_app,
+    flash,
     g,
     jsonify,
     redirect,
@@ -24,6 +31,22 @@ from .forms import (
 def mdb():
     # only called in app context
     return current_app.config["MDB"]
+
+
+def _get_package_version() -> str:
+    """Get the current package version from metadata or source."""
+    try:
+        return metadata.version("bento-sts")
+    except metadata.PackageNotFoundError:
+        try:
+            pyproject_path = (
+                Path(__file__).parent.parent.parent.parent / "pyproject.toml"
+            )
+            with pyproject_path.open("rb") as f:
+                pyproject_data = tomllib.load(f)
+            return pyproject_data["project"]["version"]
+        except Exception:
+            return "Development"
 
 
 @bp.before_app_request
@@ -581,4 +604,307 @@ def all_cde_pvs_and_synonyms():
         title="CDE Permissible Values and Synonyms",
         ents=ents,
         display="cdes",
+    )
+
+
+# =============================================================================
+# ADMIN ROUTES - Cache Management Tools
+# =============================================================================
+
+
+@bp.route("/admin/", methods=["GET"])
+@bp.route("/admin/dashboard", methods=["GET"])
+def admin_dashboard() -> str:
+    """Admin dashboard with cache management tools."""
+    package_version = _get_package_version()
+
+    return render_template(
+        "admin_dashboard.html",
+        title="Admin Dashboard",
+        package_version=package_version,
+    )
+
+
+@bp.route("/admin/clear-lru-caches", methods=["POST"])
+def admin_clear_lru_caches() -> str:
+    """Clear all LRU caches from the mdb class."""
+    try:
+        cleared_count = 0
+
+        if hasattr(type(mdb()).get_term_batch, "cache_clear"):
+            type(mdb()).get_term_batch.cache_clear()
+            cleared_count += 1
+
+        if hasattr(type(mdb()).get_model_pvs_synonyms, "cache_clear"):
+            type(mdb()).get_model_pvs_synonyms.cache_clear()
+            cleared_count += 1
+
+        if hasattr(type(mdb()).get_cde_pvs_by_id, "cache_clear"):
+            type(mdb()).get_cde_pvs_by_id.cache_clear()
+            cleared_count += 1
+
+        if hasattr(type(mdb()).get_term_nanoid_by_origin, "cache_clear"):
+            type(mdb()).get_term_nanoid_by_origin.cache_clear()
+            cleared_count += 1
+
+        if hasattr(type(mdb()).get_cde_pvs_and_synonyms_by_id, "cache_clear"):
+            type(mdb()).get_cde_pvs_and_synonyms_by_id.cache_clear()
+            cleared_count += 1
+
+        if hasattr(type(mdb()).get_all_pvs_and_synonyms, "cache_clear"):
+            type(mdb()).get_all_pvs_and_synonyms.cache_clear()
+            cleared_count += 1
+
+        flash(f"Cleared {cleared_count} LRU caches successfully.", "success")
+
+    except Exception as e:
+        current_app.logger.exception("Error clearing LRU caches")
+        flash(f"Error clearing LRU caches: {e!s}", "error")
+
+    return redirect(url_for("main.admin_dashboard"))
+
+
+@bp.route("/admin/refresh-mdb", methods=["POST"])
+def admin_refresh_mdb() -> str:
+    """Refresh the MDB/SearchableMDB instance."""
+    try:
+        if (
+            current_app.config["MDB"]
+            and hasattr(current_app.config["MDB"], "mdb_")
+            and current_app.config["MDB"].mdb_
+        ):
+            current_app.config["MDB"].mdb_.close()
+
+        type(mdb()).mdb_ = None
+
+        current_app.config["MDB"] = type(mdb())(
+            current_app.config["NEO4J_MDB_URI"],
+            current_app.config["NEO4J_MDB_USER"],
+            current_app.config["NEO4J_MDB_PASS"],
+        )
+
+        flash(
+            "MDB instance refreshed successfully (includes search indexes).",
+            "success",
+        )
+
+    except Exception as e:
+        current_app.logger.exception("Error refreshing MDB")
+        flash(f"Error refreshing MDB: {e!s}", "error")
+
+    return redirect(url_for("main.admin_dashboard"))
+
+
+@bp.route("/admin/refresh-model-lists", methods=["POST"])
+def admin_refresh_model_lists() -> str:
+    """Regenerate model lists from MDB."""
+    try:
+        type(mdb()).term_values = None
+
+        minfo = current_app.config["MDB"].mdb_.get_model_info()
+
+        current_app.config["MODEL_LIST"] = sorted({x["handle"] for x in minfo})
+        current_app.config["VERSIONS_BY_MODEL"] = {}
+        current_app.config["LATEST_VERSION_BY_MODEL"] = {}
+
+        # Rebuild version mappings
+        for m in current_app.config["MODEL_LIST"]:
+            for info in [x for x in minfo if x["handle"] == m]:
+                if current_app.config["VERSIONS_BY_MODEL"].get(m):
+                    current_app.config["VERSIONS_BY_MODEL"][m].append(info["version"])
+                else:
+                    current_app.config["VERSIONS_BY_MODEL"][m] = [info["version"]]
+                if (
+                    info.get("latest_version") == True
+                    or info.get("is_latest_version") == True
+                ):
+                    current_app.config["LATEST_VERSION_BY_MODEL"][m] = info["version"]
+
+        for m in current_app.config["MODEL_LIST"]:
+            if not current_app.config["LATEST_VERSION_BY_MODEL"].get(m):
+                current_app.config["LATEST_VERSION_BY_MODEL"][m] = current_app.config[
+                    "VERSIONS_BY_MODEL"
+                ][m][0]
+
+        if "ALL" not in current_app.config["MODEL_LIST"]:
+            current_app.config["MODEL_LIST"].insert(0, "ALL")
+
+        model_count = len(current_app.config["MODEL_LIST"]) - 1
+        flash(
+            f"Model lists refreshed successfully ({model_count} models found).",
+            "success",
+        )
+
+    except Exception as e:
+        current_app.logger.exception("Error refreshing model lists")
+        flash(f"Error refreshing model lists: {e!s}", "error")
+
+    return redirect(url_for("main.admin_dashboard"))
+
+
+@bp.route("/admin/clear-all-caches", methods=["POST"])
+def admin_clear_all_caches():
+    """Clear all caches: LRU caches, refresh MDB, and regenerate model lists."""
+    try:
+        cleared_lru = 0
+        if hasattr(type(mdb()).get_term_batch, "cache_clear"):
+            type(mdb()).get_term_batch.cache_clear()
+            cleared_lru += 1
+        if hasattr(type(mdb()).get_model_pvs_synonyms, "cache_clear"):
+            type(mdb()).get_model_pvs_synonyms.cache_clear()
+            cleared_lru += 1
+        if hasattr(type(mdb()).get_cde_pvs_by_id, "cache_clear"):
+            type(mdb()).get_cde_pvs_by_id.cache_clear()
+            cleared_lru += 1
+        if hasattr(type(mdb()).get_term_nanoid_by_origin, "cache_clear"):
+            type(mdb()).get_term_nanoid_by_origin.cache_clear()
+            cleared_lru += 1
+        if hasattr(type(mdb()).get_cde_pvs_and_synonyms_by_id, "cache_clear"):
+            type(mdb()).get_cde_pvs_and_synonyms_by_id.cache_clear()
+            cleared_lru += 1
+        if hasattr(type(mdb()).get_all_pvs_and_synonyms, "cache_clear"):
+            type(mdb()).get_all_pvs_and_synonyms.cache_clear()
+            cleared_lru += 1
+
+        type(mdb()).term_values = None
+
+        if current_app.config["MDB"] and hasattr(current_app.config["MDB"], "mdb_"):
+            if current_app.config["MDB"].mdb_ and hasattr(
+                current_app.config["MDB"].mdb_,
+                "close",
+            ):
+                current_app.config["MDB"].mdb_.close()
+
+        type(mdb()).mdb_ = None
+        current_app.config["MDB"] = type(mdb())(
+            current_app.config["NEO4J_MDB_URI"],
+            current_app.config["NEO4J_MDB_USER"],
+            current_app.config["NEO4J_MDB_PASS"],
+        )
+
+        minfo = current_app.config["MDB"].mdb_.get_model_info()
+        current_app.config["MODEL_LIST"] = sorted({x["handle"] for x in minfo})
+        current_app.config["VERSIONS_BY_MODEL"] = {}
+        current_app.config["LATEST_VERSION_BY_MODEL"] = {}
+
+        for m in current_app.config["MODEL_LIST"]:
+            for info in [x for x in minfo if x["handle"] == m]:
+                if current_app.config["VERSIONS_BY_MODEL"].get(m):
+                    current_app.config["VERSIONS_BY_MODEL"][m].append(info["version"])
+                else:
+                    current_app.config["VERSIONS_BY_MODEL"][m] = [info["version"]]
+                if (
+                    info.get("latest_version") == True
+                    or info.get("is_latest_version") == True
+                ):
+                    current_app.config["LATEST_VERSION_BY_MODEL"][m] = info["version"]
+
+        for m in current_app.config["MODEL_LIST"]:
+            if not current_app.config["LATEST_VERSION_BY_MODEL"].get(m):
+                current_app.config["LATEST_VERSION_BY_MODEL"][m] = current_app.config[
+                    "VERSIONS_BY_MODEL"
+                ][m][0]
+
+        if "ALL" not in current_app.config["MODEL_LIST"]:
+            current_app.config["MODEL_LIST"].insert(0, "ALL")
+
+        model_count = len(current_app.config["MODEL_LIST"]) - 1
+        flash(
+            f"All caches cleared successfully! Refreshed {cleared_lru} LRU caches, "
+            f"MDB instance (with indexes), and {model_count} models.",
+            "success",
+        )
+
+    except Exception as e:
+        current_app.logger.exception("Error clearing all caches")
+        flash(f"Error clearing all caches: {e!s}", "error")
+
+    return redirect(url_for("main.admin_dashboard"))
+
+
+@bp.route("/admin/indexes", methods=["GET"])
+def admin_list_indexes():
+    """Compare cached vs current Neo4j indexes to test refresh behavior."""
+    try:
+        cached_indexes = mdb().mdb.available_indexes()
+
+        show_indexes_stmt = (
+            "SHOW INDEXES YIELD name, state, type, labelsOrTypes, properties "
+            "RETURN name, state, type, labelsOrTypes, properties"
+        )
+        current_indexes = mdb().get_with_statement(show_indexes_stmt, {})
+
+        current_fulltext = {
+            idx["name"]: {
+                "state": idx.get("state", "unknown"),
+                "entity_type": idx.get("labelsOrTypes", []),
+                "properties": idx.get("properties", []),
+            }
+            for idx in current_indexes
+            if idx.get("type") == "FULLTEXT"
+        }
+
+        comparison = {}
+        all_index_names = set(cached_indexes.keys()) | set(current_fulltext.keys())
+
+        for index_name in all_index_names:
+            in_cache = index_name in cached_indexes
+            in_db = index_name in current_fulltext
+
+            if in_cache and in_db:
+                comparison[index_name] = {
+                    "status": "✅ Cached and Available",
+                    "cached": cached_indexes[index_name],
+                    "current": current_fulltext[index_name],
+                }
+            elif in_cache and not in_db:
+                comparison[index_name] = {
+                    "status": "⚠️ Cached but Missing from DB",
+                    "cached": cached_indexes[index_name],
+                    "current": None,
+                }
+            elif not in_cache and in_db:
+                comparison[index_name] = {
+                    "status": "🔄 Available but Not Cached (needs refresh)",
+                    "cached": None,
+                    "current": current_fulltext[index_name],
+                }
+
+        needs_refresh = any(
+            status["status"].startswith("⚠️") or status["status"].startswith("🔄")
+            for status in comparison.values()
+        )
+
+        return jsonify(
+            {
+                "cached_indexes": cached_indexes,
+                "current_fulltext_indexes": current_fulltext,
+                "comparison": comparison,
+                "needs_refresh": needs_refresh,
+                "all_indexes": current_indexes,  # Keep for debugging
+                "status": "success",
+            },
+        )
+
+    except Exception as e:
+        current_app.logger.exception("Error listing indexes")
+        return jsonify(
+            {
+                "error": str(e),
+                "status": "error",
+            },
+        ), 500
+
+
+@bp.route("/admin/version", methods=["GET"])
+def admin_version_info() -> Response:
+    """Return version information as JSON."""
+    package_version = _get_package_version()
+
+    return jsonify(
+        {
+            "package": "bento-sts",
+            "version": package_version,
+            "status": "running",
+        },
     )

--- a/python/src/bento_sts/mdb.py
+++ b/python/src/bento_sts/mdb.py
@@ -22,8 +22,9 @@ plural = {
 
 class mdb:
     """
-    Read functionality for driving STS UI. Mixins mdb_update and mdb_tags
-    could be used here for write and tag functionality.
+    Read functionality for driving STS UI.
+
+    Mixins mdb_update and mdb_tags could be used here for write and tag functionality.
     """
 
     mdb_ = None
@@ -56,7 +57,7 @@ class mdb:
                     if not ret[h].get("name"):
                         ret[h]["name"] = ret[h]["handle"]
                     ret[h]["version"] = [mdl["m"]["version"]]
-        return [x for x in ret.values()]
+        return list(ret.values())
 
     def get_model_by_name(self, name):
         model_nodes = self.mdb.get_model_nodes(model=name)

--- a/python/src/bento_sts/sts.py
+++ b/python/src/bento_sts/sts.py
@@ -35,7 +35,7 @@ def create_app(config_class=Config):
 
     minfo = app.config["MDB"].mdb_.get_model_info()
 
-    app.config["MODEL_LIST"] = sorted(set([x["handle"] for x in minfo]))
+    app.config["MODEL_LIST"] = sorted({x["handle"] for x in minfo})
     app.config["VERSIONS_BY_MODEL"] = {
         m: sorted([v["version"] for v in minfo if v["handle"] == m])
         for m in app.config["MODEL_LIST"]

--- a/python/src/bento_sts/templates/admin_dashboard.html
+++ b/python/src/bento_sts/templates/admin_dashboard.html
@@ -1,0 +1,156 @@
+{% extends "base.html" %}
+
+{% block app_content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <div>
+                    <h2>Admin Dashboard</h2>
+                    <p class="text-muted">Cache management tools for STS application</p>
+                </div>
+                <div class="text-right">
+                    <span class="badge badge-info badge-lg">
+                        <i class="bi bi-box"></i> Bento-STS v{{ package_version }}
+                    </span>
+                </div>
+            </div>
+            <hr>
+        </div>
+    </div>
+    
+    <div class="row">
+        <!-- Clear All Caches - Primary Action -->
+        <div class="col-md-6 col-lg-4 mb-4">
+            <div class="card border-primary">
+                <div class="card-header bg-primary text-white">
+                    <h5 class="card-title mb-0">
+                        <i class="bi bi-arrow-clockwise"></i> Clear All Caches
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <p class="card-text">Clears all application caches in one operation:</p>
+                    <ul class="small">
+                        <li>LRU function caches (6 functions)</li>
+                        <li>MDB/SearchableMDB instance & indexes</li>
+                        <li>Model lists and term values</li>
+                    </ul>
+                    <form method="POST" action="{{ url_for('main.admin_clear_all_caches') }}" style="display:inline;">
+                        <button type="submit" class="btn btn-primary btn-block" 
+                                onclick="return confirm('Clear all caches? This will refresh all cached data.')">
+                            <i class="bi bi-arrow-clockwise"></i> Clear All Caches
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+        
+        <!-- Individual Cache Tools -->
+        <div class="col-md-6 col-lg-8">
+            <div class="row">
+                <!-- LRU Caches -->
+                <div class="col-md-6 mb-4">
+                    <div class="card">
+                        <div class="card-header">
+                            <h6 class="card-title mb-0">
+                                <i class="bi bi-memory"></i> LRU Caches
+                            </h6>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text small">Clear function-level LRU caches for CDE data, terms, and model queries.</p>
+                            <form method="POST" action="{{ url_for('main.admin_clear_lru_caches') }}" style="display:inline;">
+                                <button type="submit" class="btn btn-outline-secondary btn-sm btn-block" 
+                                        onclick="return confirm('Clear LRU caches?')">
+                                    Clear LRU Caches
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- MDB Instance -->
+                <div class="col-md-6 mb-4">
+                    <div class="card">
+                        <div class="card-header">
+                            <h6 class="card-title mb-0">
+                                <i class="bi bi-database"></i> MDB Instance
+                            </h6>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text small">Refresh SearchableMDB connection and rebuild search indexes.</p>
+                            <form method="POST" action="{{ url_for('main.admin_refresh_mdb') }}" style="display:inline;">
+                                <button type="submit" class="btn btn-outline-secondary btn-sm btn-block" 
+                                        onclick="return confirm('Refresh MDB instance? This may take a moment.')">
+                                    Refresh MDB
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Model Lists -->
+                <div class="col-md-6 mb-4">
+                    <div class="card">
+                        <div class="card-header">
+                            <h6 class="card-title mb-0">
+                                <i class="bi bi-list-ul"></i> Model Lists
+                            </h6>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text small">Regenerate model lists, versions, and term values from database.</p>
+                            <form method="POST" action="{{ url_for('main.admin_refresh_model_lists') }}" style="display:inline;">
+                                <button type="submit" class="btn btn-outline-secondary btn-sm btn-block" 
+                                        onclick="return confirm('Refresh model lists?')">
+                                    Refresh Models
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- Search Indexes -->
+                <div class="col-md-6 mb-4">
+                    <div class="card">
+                        <div class="card-header">
+                            <h6 class="card-title mb-0">
+                                <i class="bi bi-search"></i> Search Indexes
+                            </h6>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text small">Compare cached vs. current FULLTEXT indexes to test refresh behavior.</p>
+                            <a href="{{ url_for('main.admin_list_indexes') }}" 
+                               class="btn btn-outline-info btn-sm btn-block"
+                               target="_blank">
+                                Compare Indexes (JSON)
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="row mt-4">
+        <div class="col-12">
+            <div class="alert alert-info">
+                <h6><i class="bi bi-info-circle"></i> Cache Management Info</h6>
+                <ul class="mb-0 small">
+                    <li><strong>LRU Caches:</strong> Clear Python function-level caches for improved data freshness</li>
+                    <li><strong>MDB Instance:</strong> Refresh database connection and FULLTEXT search indexes</li>
+                    <li><strong>Model Lists:</strong> Update cached model information and term values from the database</li>
+                    <li><strong>Search Indexes:</strong> View current Neo4j indexes and test search functionality</li>
+                    <li><strong>Clear All:</strong> Performs LRU + MDB + Model operations in the correct order</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    
+    <div class="row">
+        <div class="col-12 text-center">
+            <a href="{{ url_for('main.index') }}" class="btn btn-link">
+                <i class="bi bi-arrow-left"></i> Back to STS
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/python/src/bento_sts/templates/base.html
+++ b/python/src/bento_sts/templates/base.html
@@ -1,104 +1,132 @@
 <!-- -*-jinja2-*- -->
-{% from 'bootstrap4/form.html' import render_form, render_field %}
-<!doctype html>
+<!DOCTYPE html>
+{% from "bootstrap4/form.html" import render_form, render_field %}
+
 <html lang="en">
-    <head>
-      {% block head %}
-        <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        
-        <!-- Favicon -->
-        <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
-        <link rel="shortcut icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
-        
-        {% block styles %}
-          <!-- Bootstrap Icons-->
-          
-          <!-- Bootstrap CSS -->
-          {{ bootstrap.load_css() }}
-          <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet">
-          <link rel="stylesheet" href="https://code.jquery.com/ui/1.14.1/themes/base/jquery-ui.css">
-	  <link href="/static/sts.css" rel="stylesheet">
-          
-        {% endblock %}
-        
-        {% block scripts %}
-          {{ moment.include_moment() }}
-          {{ moment.lang(g.locale) }}
-          {{ bootstrap.load_js() }}
-          <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
-          <script src="https://code.jquery.com/ui/1.14.1/jquery-ui.js"></script>
-          <script>
-            $( function() {
-            $( "#tabs" ).tabs();
-            } );
-          </script>
-        {% endblock %}
-            <title>STS</title>
+  <head>
+    {% block head %}
+    <!-- Required meta tags -->
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
 
+    <!-- Favicon -->
+    <link
+      rel="icon"
+      type="image/x-icon"
+      href="{{ url_for('static', filename='favicon.ico') }}"
+    />
+    <link
+      rel="shortcut icon"
+      type="image/x-icon"
+      href="{{ url_for('static', filename='favicon.ico') }}"
+    />
 
-        {% endblock %}
-    </head>
+    {% block styles %}
+    <!-- Bootstrap Icons-->
 
-    <body>
+    <!-- Bootstrap CSS -->
+    {{ bootstrap.load_css() }}
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://code.jquery.com/ui/1.14.1/themes/base/jquery-ui.css"
+    />
+    <link href="/static/sts.css" rel="stylesheet" />
 
-        {% block navbar %}
-        
-            <nav class="navbar navbar-expand-md navbar-dark bg-primary">
+    {% endblock %} {% block scripts %} {{ moment.include_moment() }} {{
+    moment.lang(g.locale) }} {{ bootstrap.load_js() }}
+    <script src="https://code.jquery.com/jquery-3.7.1.js"></script>
+    <script src="https://code.jquery.com/ui/1.14.1/jquery-ui.js"></script>
+    <script>
+      $(function () {
+        $("#tabs").tabs();
+      });
+    </script>
+    {% endblock %}
+    <title>STS</title>
 
-                <a class="navbar-brand" href="{{ url_for('main.index') }}">STS</a>
+    {% endblock %}
+  </head>
 
-                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
+  <body>
+    {% block navbar %}
 
-                <div class="collapse navbar-collapse" id="navbarNav">
-                        <ul class="navbar-nav  mr-auto">    
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ url_for('main.models') }}">{{ 'Models' }}</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ url_for('main.entities',entities='nodes') }}">{{ 'Nodes' }}</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ url_for('main.entities',entities='properties') }}">{{ 'Properties' }}</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="{{ url_for('main.entities',entities='terms') }}">{{ 'Terms' }}</a>
-                            </li>
-			    <li class="nav-item">
-			      <a class="nav-link" href="{{ url_for('main.tags') }}">{{ 'Tags' }}</a>
-			    </li>
-                        </ul>
-                        {% if g.search_form %}
-			  {{ render_form( g.search_form, form_type="inline", method="get",
-			  action=url_for("main.search"), extra_classes="my-2 my-md-0",
-			  button_size="sm",
-			  button_map={"models":"outline-light", "terms":"outline-light"} ) }}"
-                        {% endif %}
-                    </div>
+    <nav class="navbar navbar-expand-md navbar-dark bg-primary">
+      <a class="navbar-brand" href="{{ url_for('main.index') }}">STS</a>
 
-                    
-            </nav>
-        
-        {% endblock %}
+      <button
+        class="navbar-toggler"
+        type="button"
+        data-toggle="collapse"
+        data-target="#navbarNav"
+        aria-controls="navbarNav"
+        aria-expanded="false"
+        aria-label="Toggle navigation"
+      >
+        <span class="navbar-toggler-icon"></span>
+      </button>
 
-        {% block content %}
-            <div class="container">
-                {% with messages = get_flashed_messages() %}
-                {% if messages %}
-                    {% for message in messages %}
-                    <div class="alert alert-info" role="alert">{{ message }}</div>
-                    {% endfor %}
-                {% endif %}
-                {% endwith %}
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('main.models') }}"
+              >{{ 'Models' }}</a
+            >
+          </li>
+          <li class="nav-item">
+            <a
+              class="nav-link"
+              href="{{ url_for('main.entities',entities='nodes') }}"
+              >{{ 'Nodes' }}</a
+            >
+          </li>
+          <li class="nav-item">
+            <a
+              class="nav-link"
+              href="{{ url_for('main.entities',entities='properties') }}"
+              >{{ 'Properties' }}</a
+            >
+          </li>
+          <li class="nav-item">
+            <a
+              class="nav-link"
+              href="{{ url_for('main.entities',entities='terms') }}"
+              >{{ 'Terms' }}</a
+            >
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('main.tags') }}"
+              >{{ 'Tags' }}</a
+            >
+          </li>
+        </ul>
+        {% if g.search_form %} {{ render_form( g.search_form,
+        form_type="inline", method="get", action=url_for("main.search"),
+        extra_classes="my-2 my-md-0", button_size="sm",
+        button_map={"models":"outline-light", "terms":"outline-light"} ) }}" {%
+        endif %}
+      </div>
+    </nav>
 
-                {# application content needs to be provided in the app_content block #}
-                
-                {% block app_content %}{% endblock %}
-
-            </div>
-        {% endblock %}
-</body>
+    {% endblock %} {% block content %}
+    <div class="container">
+      {% with messages = get_flashed_messages(with_categories=true) %} {% if
+      messages %} {% for category, message in messages %}
+      <div
+        class="alert alert-{{ 'success' if category == 'success' else ('danger' if category == 'error' else 'info') }}"
+        role="alert"
+      >
+        {{ message }}
+      </div>
+      {% endfor %} {% endif %} {% endwith %} {# application content needs to be
+      provided in the app_content block #} {% block app_content %}{% endblock %}
+    </div>
+    {% endblock %}
+  </body>
 </html>


### PR DESCRIPTION
Add admin dashboard and routes:
- /admin/clear-lru-caches to clear cached values for functions that use the lru_cache decorator
- /admin/refresh-mdb to refresh connection to MDB using uri, username, and password set in the app environment
- /admin/refresh-model-lists to reload current app model list for model id links
- /admin/clear-all-caches to do all the above
- /admin/indexes to list all cached indexes and current Neo4j indexes
- /admin/version to get current bento-sts package version used by app