### PR TITLE
perf(mdb): remove LRU caching from pv endpoints

### DIFF
--- a/python/src/bento_sts/main/routes.py
+++ b/python/src/bento_sts/main/routes.py
@@ -481,7 +481,7 @@ def cde_pvs_and_synonyms_by_model(model, version):
     else:
         pass
 
-    ents = type(mdb()).get_model_pvs_synonyms(model, version)
+    ents = mdb().get_model_pvs_synonyms(model, version)
 
     if fmt == "json":
         # remove attrs other than values from props
@@ -519,7 +519,7 @@ def cde_pvs_by_id(id, version):
     else:
         pass
 
-    ents = type(mdb()).get_cde_pvs_by_id(cde_id, cde_version)
+    ents = mdb().get_cde_pvs_by_id(cde_id, cde_version)
 
     if fmt == "json":
         return jsonify(
@@ -561,8 +561,7 @@ def term_by_origin(origin_name, origin_id, origin_version):
     origin_version = origin_version or request.args.get("origin_version") or ""
 
     term_nanoids = (
-        type(mdb()).get_term_nanoid_by_origin(origin_name, origin_id, origin_version)
-        or []
+        mdb().get_term_nanoid_by_origin(origin_name, origin_id, origin_version) or []
     )
     if term_nanoids:
         term_nanoid = term_nanoids[0]["term_nanoid"]
@@ -598,7 +597,7 @@ def all_cde_pvs_and_synonyms():
     else:
         pass
 
-    ents = type(mdb()).get_all_pvs_and_synonyms()
+    ents = mdb().get_all_pvs_and_synonyms()
 
     if fmt == "json":
         # remove attrs other than values from props
@@ -639,27 +638,7 @@ def admin_clear_lru_caches() -> str:
             type(mdb()).get_term_batch.cache_clear()
             cleared_count += 1
 
-        if hasattr(type(mdb()).get_model_pvs_synonyms, "cache_clear"):
-            type(mdb()).get_model_pvs_synonyms.cache_clear()
-            cleared_count += 1
-
-        if hasattr(type(mdb()).get_cde_pvs_by_id, "cache_clear"):
-            type(mdb()).get_cde_pvs_by_id.cache_clear()
-            cleared_count += 1
-
-        if hasattr(type(mdb()).get_term_nanoid_by_origin, "cache_clear"):
-            type(mdb()).get_term_nanoid_by_origin.cache_clear()
-            cleared_count += 1
-
-        if hasattr(type(mdb()).get_cde_pvs_and_synonyms_by_id, "cache_clear"):
-            type(mdb()).get_cde_pvs_and_synonyms_by_id.cache_clear()
-            cleared_count += 1
-
-        if hasattr(type(mdb()).get_all_pvs_and_synonyms, "cache_clear"):
-            type(mdb()).get_all_pvs_and_synonyms.cache_clear()
-            cleared_count += 1
-
-        flash(f"Cleared {cleared_count} LRU caches successfully.", "success")
+        flash(f"Cleared {cleared_count} LRU cache(s) successfully.", "success")
 
     except Exception as e:
         current_app.logger.exception("Error clearing LRU caches")
@@ -754,21 +733,6 @@ def admin_clear_all_caches():
         if hasattr(type(mdb()).get_term_batch, "cache_clear"):
             type(mdb()).get_term_batch.cache_clear()
             cleared_lru += 1
-        if hasattr(type(mdb()).get_model_pvs_synonyms, "cache_clear"):
-            type(mdb()).get_model_pvs_synonyms.cache_clear()
-            cleared_lru += 1
-        if hasattr(type(mdb()).get_cde_pvs_by_id, "cache_clear"):
-            type(mdb()).get_cde_pvs_by_id.cache_clear()
-            cleared_lru += 1
-        if hasattr(type(mdb()).get_term_nanoid_by_origin, "cache_clear"):
-            type(mdb()).get_term_nanoid_by_origin.cache_clear()
-            cleared_lru += 1
-        if hasattr(type(mdb()).get_cde_pvs_and_synonyms_by_id, "cache_clear"):
-            type(mdb()).get_cde_pvs_and_synonyms_by_id.cache_clear()
-            cleared_lru += 1
-        if hasattr(type(mdb()).get_all_pvs_and_synonyms, "cache_clear"):
-            type(mdb()).get_all_pvs_and_synonyms.cache_clear()
-            cleared_lru += 1
 
         type(mdb()).term_values = None
 
@@ -814,7 +778,7 @@ def admin_clear_all_caches():
 
         model_count = len(current_app.config["MODEL_LIST"]) - 1
         flash(
-            f"All caches cleared successfully! Refreshed {cleared_lru} LRU caches, "
+            f"All caches cleared successfully! Refreshed {cleared_lru} LRU cache(s), "
             f"MDB instance (with indexes), and {model_count} models.",
             "success",
         )

--- a/python/src/bento_sts/mdb.py
+++ b/python/src/bento_sts/mdb.py
@@ -464,9 +464,11 @@ class mdb:
     # CDE PVs & Synonyms
     # ####################################################################### #
 
-    @functools.lru_cache
-    @staticmethod
-    def get_model_pvs_synonyms(model: str | None = None, version: str | None = None):
+    def get_model_pvs_synonyms(
+        self,
+        model: str | None = None,
+        version: str | None = None,
+    ):
         qry = (
             "MATCH (n {model: $dataCommons, version: $version})-[:has_property]->"
             "(p:property) "
@@ -512,11 +514,9 @@ class mdb:
 
         parms = {"dataCommons": model, "version": version}
 
-        return mdb.mdb_.get_with_statement(qry, parms)
+        return self.mdb.get_with_statement(qry, parms)
 
-    @functools.lru_cache
-    @staticmethod
-    def get_cde_pvs_by_id(id: str | None = None, version: str | None = None):
+    def get_cde_pvs_by_id(self, id: str | None = None, version: str | None = None):
         """Get CDE PVs and synonyms for a given CDE id and optional version."""
         qry = (
             "MATCH (cde:term {origin_id: $cde_id}) "
@@ -549,11 +549,10 @@ class mdb:
         )
         parms = {"cde_id": id, "cde_version": version}
 
-        return mdb.mdb_.get_with_statement(qry, parms)
+        return self.mdb.get_with_statement(qry, parms)
 
-    @functools.lru_cache
-    @staticmethod
     def get_term_nanoid_by_origin(
+        self,
         origin_name: str | None = None,
         origin_id: str | None = None,
         origin_version: str | None = None,
@@ -572,11 +571,10 @@ class mdb:
             "origin_version": origin_version,
         }
 
-        return mdb.mdb_.get_with_statement(qry, parms)
+        return self.mdb.get_with_statement(qry, parms)
 
-    @functools.lru_cache
-    @staticmethod
     def get_cde_pvs_and_synonyms_by_id(
+        self,
         id: str | None = None,
         version: str | None = None,
     ):
@@ -591,11 +589,9 @@ class mdb:
         )
         parms = {"cde_id": id, "cde_version": version}
 
-        return mdb.mdb_.get_with_statement(qry, parms)
+        return self.mdb.get_with_statement(qry, parms)
 
-    @functools.lru_cache
-    @staticmethod
-    def get_all_pvs_and_synonyms():
+    def get_all_pvs_and_synonyms(self):
         """Get all CDE PVs and synonyms used by models in MDB."""
         qry = (
             "MATCH (cde:term) WHERE toLower(cde.origin_name) CONTAINS 'cadsr' WITH cde "
@@ -634,4 +630,4 @@ class mdb:
             "RETURN cde.origin_id AS CDECode, cde.origin_version AS CDEVersion, "
             "cde.value AS CDEFullName, models, formatted_pvs AS permissibleValues "
         )
-        return mdb.mdb_.get_with_statement(qry, {})
+        return self.mdb.get_with_statement(qry, {})


### PR DESCRIPTION
Remove @functools.lru_cache decorators from five PV-related functions:
- get_all_pvs_and_synonyms
- get_cde_pvs_and_synonyms_by_id
- get_term_nanoid_by_origin
- get_cde_pvs_by_id
- get_model_pvs_synonyms

Convert these functions from static methods to instance methods for consistency with other mdb class methods. Update route handlers to use mdb() instance pattern and clean up admin cache clearing logic.

Fixes DATATEAM-236